### PR TITLE
Gradle install sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,10 +71,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>

--- a/src/it/check-invoke-it/pom.xml
+++ b/src/it/check-invoke-it/pom.xml
@@ -12,10 +12,9 @@
     <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
-            <source>17</source>
-            <target>17</target>
+			<release>17</release>
         </configuration>
     </plugin>
 	<plugin>

--- a/src/it/check-invoke-it/pom.xml
+++ b/src/it/check-invoke-it/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.thingsboard</groupId>
   <artifactId>check-invoke-it</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.12</version>
+  <version>1.0.13</version>
   <name>gradle-maven-plugin Maven Mojo</name>
   <url>http://maven.apache.org</url>
 <build>
@@ -20,7 +20,7 @@
 	<plugin>
 	      <groupId>org.thingsboard</groupId>
 	      <artifactId>gradle-maven-plugin</artifactId>
-	      <version>1.0.12</version>
+	      <version>1.0.13</version>
 	        <configuration>
 	        	<tasks>
 					<task>doIt</task>

--- a/src/it/main-it/pom.xml
+++ b/src/it/main-it/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.thingsboard.test</groupId>
   <artifactId>gradle-maven-plugin-test</artifactId>
   <packaging>jar</packaging>
-    <version>1.0.12</version>
+  <version>1.0.13</version>
   <name>gradle-maven-plugin Maven Mojo</name>
   <url>http://maven.apache.org</url>
 <build>
@@ -20,7 +20,7 @@
 	<plugin>
         <groupId>org.thingsboard</groupId>
         <artifactId>gradle-maven-plugin</artifactId>
-        <version>1.0.12</version>
+        <version>1.0.13</version>
 	        <configuration>
 	        	<tasks>
 					<task>clean</task>

--- a/src/it/main-it/pom.xml
+++ b/src/it/main-it/pom.xml
@@ -12,10 +12,9 @@
     <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.11.0</version>
         <configuration>
-            <source>17</source>
-            <target>17</target>
+            <release>17</release>
         </configuration>
     </plugin>
 	<plugin>

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -225,7 +225,9 @@ public class GradleMojo extends AbstractMojo {
 				c = c.useDistribution(new URI(gradleDistribution));
 			}
 
-			connection = c.connect();
+			synchronized (this) {
+				connection = c.connect();
+			}
 
 			BuildLauncher launcher = connection.newBuild();
 			launcher.forTasks(getTasks());


### PR DESCRIPTION
The motivation is to handle installation issues during multi-threaded builds in the fresh environment or after Gradle version update like

```
14:50:23   [INFO] --- gradle-maven-plugin:1.0.11:invoke (default) @ http ---
14:50:24   [INFO] jvmArgs: [Ljava.lang.String;@23c94fe0
14:50:24   [INFO] gradleProjectDirectory: /opt/buildagent/work/c88004f80b096137/transport/http/../../packaging/java
14:50:24   [INFO] Build
14:50:24   Downloading https://services.gradle.org/distributions/gradle-7.1.1-bin.zip
14:50:24   [INFO] Download https://services.gradle.org/distributions/gradle-7.1.1-bin.zip
14:50:25   ..............................................................................
14:50:25   [INFO] Build
14:50:25   [INFO]
14:50:25   Failed to execute goal org.thingsboard:gradle-maven-plugin:1.0.11:invoke (default) on project http: org.gradle.tooling.GradleConnectionException: Could not install Gradle distribution from 'https://services.gradle.org/distributions/gradle-7.1.1-bin.zip'.
```

Local build is ok:
```
mvn clean install
```

![image](https://github.com/thingsboard/gradle-maven-plugin/assets/79898499/07839edb-e6bd-4fbe-a847-0ab4e5b5885a)
