### PR TITLE
Serialize Gradle invocations to prevent parallel build contention

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.thingsboard</groupId>
     <artifactId>gradle-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>1.0.15</version>
+    <version>1.0.16</version>
     <name>gradle-maven-plugin Maven Mojo</name>
     <url>https://github.com/LendingClub/gradle-maven-plugin</url>
     <parent>

--- a/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
+++ b/src/main/java/org/fortasoft/maven/plugin/gradle/GradleMojo.java
@@ -37,6 +37,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Goal which invokes gradle!
@@ -44,6 +46,14 @@ import java.util.Map;
  */
 @Mojo(name="invoke", threadSafe = true)
 public class GradleMojo extends AbstractMojo {
+
+	/**
+	 * Serializes all Gradle invocations across the Maven reactor.
+	 * Gradle Tooling API uses a shared daemon registry and project cache,
+	 * so parallel executions (-T N) cause file lock contention. A static
+	 * lock ensures only one Gradle build runs at a time per JVM.
+	 */
+	private static final Lock GRADLE_LOCK = new ReentrantLock();
 
 	/**
 		Any maven property with this prefix automatically gets added as a 
@@ -191,6 +201,7 @@ public class GradleMojo extends AbstractMojo {
 
 	public void execute() throws MojoExecutionException, MojoFailureException {
 
+		GRADLE_LOCK.lock();
 		ProjectConnection connection = null;
 		try {
 			NewMojoLogger.attachMojo(this);
@@ -271,6 +282,7 @@ public class GradleMojo extends AbstractMojo {
 				connection.close();
 			}
 			NewMojoLogger.detachMojo();
+			GRADLE_LOCK.unlock();
 		}
 	}
 


### PR DESCRIPTION
## Problem

When Maven runs with `-T N`, multiple modules invoke the Gradle Tooling API simultaneously. The shared Gradle daemon registry and project cache directories cause file lock contention, daemon racing, and in Gradle 9.3.1 — `TimeoutException` from the async problems report writer.

## Fix

Add a static `ReentrantLock` that serializes all Gradle `execute()` calls within the JVM. Only one Gradle build runs at a time regardless of Maven's thread count.

This eliminates:
- Gradle daemon registry contention
- `.gradle/` project cache file lock races  
- Tooling API connection racing on the same project directory

## Notes

- The lock is `static` so it is shared across all Mojo instances in the reactor
- `GRADLE_LOCK.unlock()` is in the `finally` block so it always releases even on failure
- Bumps version to `1.0.16`